### PR TITLE
Allow create_macaroon_secret to run as non-root user

### DIFF
--- a/osg-xrootd/osg/create_macaroon_secret
+++ b/osg-xrootd/osg/create_macaroon_secret
@@ -9,8 +9,6 @@ fail () {
     exit 1
 }
 
-[[ `id -u` -eq 0 ]] || fail "Permission denied.  This must be run as root."
-
 macaroon_secret_file=$default_macaroon_secret
 
 if [[ -e $macaroon_secret_file ]]; then
@@ -19,6 +17,7 @@ fi
 
 (
     umask 377 && \
-    openssl rand -base64 -out $macaroon_secret_file 64 && \
-    chown xrootd:xrootd $macaroon_secret_file
+    openssl rand -base64 -out $macaroon_secret_file 64
 ) || fail "Couldn't create '$macaroon_secret_file'."
+
+[[ `id -u` -eq 0 ]] && chown xrootd:xrootd $macaroon_secret_file


### PR DESCRIPTION
If run as root, it will maintain the current behavior: create the secret
and change the ownership to xrootd.

If run as user, it will attempt to create the secret only.